### PR TITLE
Handle location service before map

### DIFF
--- a/lib/Account/Addresses/edit_address.dart
+++ b/lib/Account/Addresses/edit_address.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:location/location.dart' as loc;
 import 'package:allgoz/services/location_picker.dart';
 
 class EditAddressScreen extends StatefulWidget {
@@ -31,6 +32,7 @@ class _EditAddressScreenState extends State<EditAddressScreen> {
   String _addressType = 'Home';
   bool _isFetchingLocation = false;
   bool _isSavingAddress = false;
+  loc.Location location = loc.Location();
   double? latitude;
   double? longitude;
 
@@ -131,6 +133,113 @@ class _EditAddressScreenState extends State<EditAddressScreen> {
     }
   }
 
+  Future<bool> _showLocationBottomSheet() async {
+    await showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (context) => Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.location_off, size: 50, color: Colors.red),
+            const SizedBox(height: 10),
+            const Text(
+              'Your device location is off',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 10),
+            const Text(
+              'Please enable location permission for better delivery experience',
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.green,
+                minimumSize: const Size(double.infinity, 50),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(9),
+                ),
+              ),
+              onPressed: () async {
+                bool serviceEnabled = await location.requestService();
+                if (serviceEnabled) {
+                  Navigator.pop(context);
+                }
+              },
+              child: const Text(
+                'Continue',
+                style: TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 18),
+              ),
+            ),
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text(
+                'Cancel',
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 15),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    return await location.serviceEnabled();
+  }
+
+  Future<void> _selectDeliveryLocation() async {
+    bool serviceEnabled = await location.serviceEnabled();
+    if (!serviceEnabled) {
+      serviceEnabled = await _showLocationBottomSheet();
+      if (!serviceEnabled) return;
+    }
+
+    LocationPermission permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied) {
+        return;
+      }
+    }
+
+    if (permission == LocationPermission.deniedForever) {
+      await Geolocator.openAppSettings();
+      return;
+    }
+
+    final LatLng? selected = await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => LocationPickerScreen(
+          initialLocation: latitude != null && longitude != null
+              ? LatLng(latitude!, longitude!)
+              : null,
+        ),
+      ),
+    );
+
+    if (selected != null) {
+      setState(() {
+        latitude = selected.latitude;
+        longitude = selected.longitude;
+        _locationController.text =
+            'Latitude: ${latitude!.toStringAsFixed(5)}, Longitude: ${longitude!.toStringAsFixed(5)}';
+      });
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Location updated!')),
+      );
+    }
+  }
+
   void _saveAddress() async {
     if (_formKey.currentState!.validate()) {
       setState(() => _isSavingAddress = true);
@@ -208,31 +317,7 @@ class _EditAddressScreenState extends State<EditAddressScreen> {
               SizedBox(height: 10 * scaleFactor),
 
               ElevatedButton(
-                onPressed: () async {
-                  final LatLng? selected = await Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => LocationPickerScreen(
-                        initialLocation: latitude != null && longitude != null
-                            ? LatLng(latitude!, longitude!)
-                            : null,
-                      ),
-                    ),
-                  );
-
-                  if (selected != null) {
-                    setState(() {
-                      latitude = selected.latitude;
-                      longitude = selected.longitude;
-                      _locationController.text =
-                      'Latitude: ${latitude!.toStringAsFixed(5)}, Longitude: ${longitude!.toStringAsFixed(5)}';
-                    });
-
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text('Location updated!')),
-                    );
-                  }
-                },
+                onPressed: _selectDeliveryLocation,
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Colors.blue,
                   padding: EdgeInsets.symmetric(vertical: 14 * scaleFactor),

--- a/lib/services/location_picker.dart
+++ b/lib/services/location_picker.dart
@@ -37,7 +37,11 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
       bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
       if (!serviceEnabled) {
         await Geolocator.openLocationSettings();
-        return;
+        serviceEnabled = await Geolocator.isLocationServiceEnabled();
+        if (!serviceEnabled) {
+          setState(() => _isLoading = false);
+          return;
+        }
       }
 
       LocationPermission permission = await Geolocator.checkPermission();
@@ -45,18 +49,19 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
         permission = await Geolocator.requestPermission();
       }
 
-      if (permission == LocationPermission.deniedForever) {
-        await Geolocator.openAppSettings();
+      if (permission == LocationPermission.denied ||
+          permission == LocationPermission.deniedForever) {
+        setState(() => _isLoading = false);
         return;
       }
 
       final pos = await Geolocator.getCurrentPosition();
       _selectedLatLng = LatLng(pos.latitude, pos.longitude);
       _latLngText =
-      "Latitude: ${pos.latitude.toStringAsFixed(5)}, Longitude: ${pos.longitude.toStringAsFixed(5)}";
+          "Latitude: ${pos.latitude.toStringAsFixed(5)}, Longitude: ${pos.longitude.toStringAsFixed(5)}";
       setState(() => _isLoading = false);
     } catch (e) {
-      _selectedLatLng = const LatLng(10.3851, 77.7555); // fallback
+      _selectedLatLng = const LatLng(10.3851, 77.7555);
       _latLngText = "Lat: 10.3851, Lng: 77.7555";
       setState(() => _isLoading = false);
     }

--- a/lib/services/location_picker.dart
+++ b/lib/services/location_picker.dart
@@ -84,8 +84,20 @@ class _LocationPickerScreenState extends State<LocationPickerScreen> {
   void _centerToCurrentLocation() async {
     final pos = await Geolocator.getCurrentPosition();
     final newLatLng = LatLng(pos.latitude, pos.longitude);
-    _mapController?.animateCamera(CameraUpdate.newLatLngZoom(newLatLng, 17));
-    _updateLatLng(newLatLng);
+    await _mapController?.animateCamera(
+        CameraUpdate.newLatLngZoom(newLatLng, 17));
+    if (_mapController != null) {
+      final size = MediaQuery.of(context).size;
+      final center = await _mapController!.getLatLng(
+        ScreenCoordinate(
+          x: (size.width / 2).round(),
+          y: (size.height / 2).round(),
+        ),
+      );
+      _updateLatLng(center);
+    } else {
+      _updateLatLng(newLatLng);
+    }
   }
 
   void _toggleMapType() {


### PR DESCRIPTION
## Summary
- guard location availability before launching the map picker when adding an address
- request enabling location with a bottom sheet
- retry permissions and open settings as needed
- improve initialization logic in the map picker to handle disabled location

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688500e1cdcc833190e25f9d183ab79b