### PR TITLE
Fix version comparison for update checker

### DIFF
--- a/lib/Home/home.dart
+++ b/lib/Home/home.dart
@@ -19,6 +19,7 @@ import 'dart:ui'; // for ImageFilter (blur)
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:allgoz/services/tutorial_service.dart';
 import 'package:tutorial_coach_mark/tutorial_coach_mark.dart';
+import 'package:allgoz/utility/update_checker.dart';
 
 
 class HomePage extends StatefulWidget {
@@ -70,6 +71,10 @@ class _HomePageState extends State<HomePage> {
           curve: Curves.easeInOut,
         );
       }
+    });
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      UpdateChecker.checkForUpdate(context);
     });
 
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -8,7 +8,6 @@ import 'package:allgoz/Home/cards.dart';
 import 'package:allgoz/Home/storedetails.dart';
 import 'package:allgoz/login.dart';
 import 'package:allgoz/entername.dart';
-import 'package:allgoz/utility/update_checker.dart';
 import 'package:allgoz/services/notification_service.dart';
 
 Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
@@ -100,16 +99,7 @@ class _MyAppState extends State<MyApp> {
 
         return MaterialApp(
           debugShowCheckedModeBanner: false,
-          home: Builder(
-            builder: (context) {
-              // ✅ This ensures MaterialLocalizations are available
-              WidgetsBinding.instance.addPostFrameCallback((_) {
-                UpdateChecker.checkForUpdate(context);
-              });
-
-              return snapshot.data!;
-            },
-          ),
+          home: snapshot.data!,
           onGenerateRoute: (settings) {
             if (settings.name == '/Home/cards') {
               final args = settings.arguments as String?;

--- a/lib/utility/update_checker.dart
+++ b/lib/utility/update_checker.dart
@@ -1,9 +1,32 @@
+import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class UpdateChecker {
+  /// Compare [latest] and [current] version strings and return `true` when
+  /// [latest] is greater than [current]. This safely handles values like
+  /// "1.0.1." by ignoring empty segments and performing a numeric comparison.
+  static bool _isVersionNewer(String latest, String current) {
+    List<int> parse(String v) => v
+        .split('.')
+        .where((e) => e.isNotEmpty)
+        .map((e) => int.tryParse(e) ?? 0)
+        .toList();
+
+    final latestParts = parse(latest);
+    final currentParts = parse(current);
+    final maxLength = math.max(latestParts.length, currentParts.length);
+
+    for (var i = 0; i < maxLength; i++) {
+      final l = i < latestParts.length ? latestParts[i] : 0;
+      final c = i < currentParts.length ? currentParts[i] : 0;
+      if (l != c) return l > c;
+    }
+
+    return false; // Versions are equal
+  }
   static Future<void> checkForUpdate(BuildContext context) async {
     try {
       final PackageInfo packageInfo = await PackageInfo.fromPlatform();
@@ -22,8 +45,11 @@ class UpdateChecker {
       final changelog = data?['changelog'] ?? '';
       final playStoreUrl = data?['playstore_url'] ?? '';
 
-      // Show popup only when update is required and version is different
-      if (updateRequired && latestVersion != currentVersion) {
+      final isUpdateAvailable =
+          _isVersionNewer(latestVersion, currentVersion);
+
+      // Show popup only when update is required and the latest version is newer
+      if (updateRequired && isUpdateAvailable) {
         showDialog(
           context: context,
           barrierDismissible: false,


### PR DESCRIPTION
## Summary
- Compare current and latest versions numerically to avoid incorrect update prompts
- Only show mandatory update dialog when the latest version is higher than the installed one

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890cde127208331a964e14bbd47a83c