### PR TITLE
feat: add flexible delivery messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,17 @@ V 1.0.2+29
 - firebase_messaging: ^15.2.9
 - flutter_local_notifications: ^19.3.1
 - Added subcategories and dynamic progress bar in categories page
+
+## Delivery Message Builder Usage
+
+```dart
+final message = await buildDeliveryMessage(
+  cartCategories: cartItems.map((e) => e['category'] as String).toList(),
+  firestore: FirebaseFirestore.instance,
+);
+
+setState(() => deliveryMessage = message);
+
+// In the widget tree
+Text(deliveryMessage);
+```

--- a/lib/Cart/Checkout/checkout.dart
+++ b/lib/Cart/Checkout/checkout.dart
@@ -6,6 +6,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:allgoz/services/delivery_service.dart';
+import 'package:allgoz/services/delivery_message_builder.dart';
 import 'dart:ui';
 import 'package:intl/intl.dart';
 import 'package:allgoz/services/telegram_service.dart';
@@ -135,6 +136,7 @@ class _CheckoutScreenState extends State<CheckoutScreen> {
                     'quantity': doc['quantity'],
                     'unit': doc['unit'],
                     'grams': doc['grams'] ?? 0,
+                    'category': doc['category'],
                   };
                 }).toList();
 
@@ -321,7 +323,7 @@ class _DeliveryScreenState extends State<DeliveryScreen> with SingleTickerProvid
     _fetchUserDetails();
     _getCurrentLocation();
     _fetchPaymentMethods();
-    _fetchDeliveryMessages(); // ✅ Always fetch tomorrow’s message
+    _fetchDeliveryMessages();
 
     // _fetchCutoffTime(); // ✅ Dynamically decide based on Firestore
     // ✅ Always set to tomorrow
@@ -341,23 +343,17 @@ class _DeliveryScreenState extends State<DeliveryScreen> with SingleTickerProvid
 
 
   Future<void> _fetchDeliveryMessages() async {
-    final doc = await FirebaseFirestore.instance
-        .collection('DeliveryMessage')
-        .doc('Message')
-        .get();
-
-    if (doc.exists && doc.data() != null) {
-      final data = doc.data()!;
-      final tomorrow = DateTime.now().add(const Duration(days: 1));
-      final formattedTomorrow = DateFormat('dd/MM/yyyy').format(tomorrow);
-
-      setState(() {
-        dynamicOrderMessage = data['order'] ?? '';
-        dynamicNoteMessage = data['note'] ?? '';
-        // You can keep date separately if you want to use at end
-        dynamicOrderMessage = "$dynamicOrderMessage\n🗓📌 $formattedTomorrow";
-      });
-    }
+    final categories = widget.cartItems
+        .map((item) => (item['category'] ?? '').toString())
+        .toList();
+    final message = await buildDeliveryMessage(
+      cartCategories: categories,
+      firestore: FirebaseFirestore.instance,
+    );
+    setState(() {
+      dynamicOrderMessage = message;
+      dynamicNoteMessage = null; // notes included in message
+    });
   }
 
 

--- a/lib/Orders/track_order.dart
+++ b/lib/Orders/track_order.dart
@@ -5,6 +5,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:android_intent_plus/android_intent.dart';
 import 'package:android_intent_plus/flag.dart';
 import 'dart:io';
+import 'package:allgoz/services/delivery_message_builder.dart';
 
 class TrackCurrentOrderScreen extends StatefulWidget {
   final Map<String, dynamic> orderData;
@@ -21,21 +22,17 @@ class _TrackCurrentOrderScreenState extends State<TrackCurrentOrderScreen> {
 
 
   Future<void> _fetchDeliveryMessage() async {
-    final doc = await FirebaseFirestore.instance
-        .collection('DeliveryMessage')
-        .doc('Message')
-        .get();
-
-    if (doc.exists && doc.data() != null) {
-      final data = doc.data()!;
-      final tomorrow = DateTime.now().add(const Duration(days: 1));
-      final formattedTomorrow = "${tomorrow.day}/${tomorrow.month.toString().padLeft(2, '0')}/${tomorrow.year}";
-
-      final rawMessage = data['order'] ?? '';
-      setState(() {
-        dynamicDeliveryMessage = "$rawMessage\n📅 $formattedTomorrow";
-      });
-    }
+    final items = (widget.orderData['items'] as List<dynamic>? ?? []);
+    final categories = items
+        .map((e) => (e['category'] ?? '').toString())
+        .toList();
+    final message = await buildDeliveryMessage(
+      cartCategories: categories,
+      firestore: FirebaseFirestore.instance,
+    );
+    setState(() {
+      dynamicDeliveryMessage = message;
+    });
   }
 
 

--- a/lib/services/delivery_message_builder.dart
+++ b/lib/services/delivery_message_builder.dart
@@ -1,0 +1,135 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+/// Normalizes a product category string for comparison.
+/// - Trims spaces and converts to lowercase.
+/// - Maps singular/plural variations to a standard value.
+String normalizeCategory(String category) {
+  final normalized = category.trim().toLowerCase();
+  if (normalized == 'grocery' || normalized == 'groceries') {
+    return 'groceries';
+  }
+  if (normalized == 'fruit' || normalized == 'fruits') {
+    return 'fruits';
+  }
+  if (normalized == 'vegetable' || normalized == 'vegetables') {
+    return 'vegetables';
+  }
+  return normalized;
+}
+
+/// Returns `true` if the provided [now] (device local) time is before the
+/// given [hour] and [minute] in IST (Asia/Kolkata).
+bool isISTBefore(DateTime now, int hour, int minute) {
+  final istNow = now.toUtc().add(const Duration(hours: 5, minutes: 30));
+  final threshold = DateTime(istNow.year, istNow.month, istNow.day, hour, minute);
+  return istNow.isBefore(threshold);
+}
+
+/// Determines whether the cart contains any vegetables.
+bool hasVegetables(List<String> categories) {
+  return categories.map(normalizeCategory).contains('vegetables');
+}
+
+/// Determines whether the cart contains any fruits or groceries.
+bool hasFruitsOrGroceries(List<String> categories) {
+  final normalized = categories.map(normalizeCategory).toSet();
+  return normalized.contains('fruits') || normalized.contains('groceries');
+}
+
+/// Internal enum to represent delivery day choice.
+enum _DeliveryDay { today, tomorrow }
+
+/// Computes delivery day for vegetables based on time window.
+_DeliveryDay _vegetableRule(DateTime now) {
+  return isISTBefore(now, 8, 0) ? _DeliveryDay.today : _DeliveryDay.tomorrow;
+}
+
+/// Computes delivery day for fruits/groceries based on time window.
+_DeliveryDay _groceryRule(DateTime now) {
+  return isISTBefore(now, 16, 0) ? _DeliveryDay.today : _DeliveryDay.tomorrow;
+}
+
+/// Builds a multi-line delivery message for the given [cartCategories].
+///
+/// The Firestore document `DeliveryMessage/Message` can contain the following
+/// optional fields:
+///   - `today` : message for orders delivered today
+///   - `tomorrow` : message for orders delivered tomorrow
+///   - `order` : legacy fallback for `tomorrow`
+///   - `note` : legacy vegetable note
+///   - `noteVeg` : vegetable specific note
+///   - `noteGroceries` : groceries/fruits specific note
+///
+/// The function is backward compatible with legacy data. If `today` is missing
+/// a default message is used. If `tomorrow` is missing, `order` is used instead.
+Future<String> buildDeliveryMessage({
+  required List<String> cartCategories,
+  required FirebaseFirestore firestore,
+  DateTime? now,
+}) async {
+  final current = now ?? DateTime.now();
+  final normalized = cartCategories.map(normalizeCategory).toList();
+  final veg = hasVegetables(normalized);
+  final fg = hasFruitsOrGroceries(normalized);
+
+  // Fetch Firestore messages once
+  final doc = await firestore.collection('DeliveryMessage').doc('Message').get();
+  final data = doc.data() ?? {};
+
+  final todayText = (data['today'] as String?) ??
+      '🕗 Your order will be delivered today between 6 – 8 PM.';
+  final tomorrowText = (data['tomorrow'] as String?) ??
+      (data['order'] as String?) ??
+      '🕗 Your order will be delivered tomorrow between 6 – 8 PM.';
+  final note = data['note'] as String?;
+  final noteVeg = data['noteVeg'] as String?;
+  final noteGroceries = data['noteGroceries'] as String?;
+
+  final buffer = StringBuffer();
+
+  if (veg && !fg) {
+    final day = _vegetableRule(current);
+    buffer.write(day == _DeliveryDay.today ? todayText : tomorrowText);
+  } else if (!veg && fg) {
+    final day = _groceryRule(current);
+    buffer.write(day == _DeliveryDay.today ? todayText : tomorrowText);
+  } else if (veg && fg) {
+    final vegDay = _vegetableRule(current);
+    buffer.writeln('🥬 Vegetables — '
+        '${vegDay == _DeliveryDay.today ? todayText : tomorrowText}');
+    final groceryDay = _groceryRule(current);
+    buffer.write('🛒 Groceries/Fruits — '
+        '${groceryDay == _DeliveryDay.today ? todayText : tomorrowText}');
+  }
+
+  final notes = <String>{};
+  if (veg) {
+    if (noteVeg != null && noteVeg.isNotEmpty) notes.add(noteVeg);
+    if (note != null && note.isNotEmpty) notes.add(note);
+  }
+  if (fg) {
+    if (noteGroceries != null && noteGroceries.isNotEmpty) {
+      notes.add(noteGroceries);
+    }
+  }
+
+  if (notes.isNotEmpty) {
+    if (buffer.isNotEmpty) buffer.write('\n');
+    buffer.writeAll(notes, '\n');
+  }
+
+  return buffer.toString();
+}
+
+/*
+Example integration in checkout flow:
+
+final message = await buildDeliveryMessage(
+  cartCategories: cartItems.map((e) => e['category'] as String).toList(),
+  firestore: FirebaseFirestore.instance,
+);
+
+setState(() => dynamicOrderMessage = message);
+...
+Text(dynamicOrderMessage ?? '');
+*/

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,6 +66,7 @@ dev_dependencies:
   flutter_launcher_icons: "^0.14.3"
   flutter_native_splash: 2.4.4
   flutter_lints: ^5.0.0
+  fake_cloud_firestore: ^2.5.0
 
 flutter_launcher_icons:
 #  android: "launcher_icon"

--- a/test/delivery_message_builder_test.dart
+++ b/test/delivery_message_builder_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fake_cloud_firestore/fake_cloud_firestore.dart';
+import 'package:allgoz/services/delivery_message_builder.dart';
+
+void main() {
+  group('buildDeliveryMessage', () {
+    late FakeFirebaseFirestore firestore;
+
+    setUp(() async {
+      firestore = FakeFirebaseFirestore();
+      await firestore.collection('DeliveryMessage').doc('Message').set({
+        'today': 'today msg',
+        'tomorrow': 'tomorrow msg',
+        'noteVeg': 'veg note',
+        'noteGroceries': 'groceries note',
+      });
+    });
+
+    test('Vegetables before 8am -> today', () async {
+      final message = await buildDeliveryMessage(
+        cartCategories: ['Vegetables'],
+        firestore: firestore,
+        now: DateTime(2024, 1, 1, 7, 55),
+      );
+      expect(message.contains('today msg'), isTrue);
+    });
+
+    test('Vegetables after 8am -> tomorrow', () async {
+      final message = await buildDeliveryMessage(
+        cartCategories: ['Vegetables'],
+        firestore: firestore,
+        now: DateTime(2024, 1, 1, 9, 10),
+      );
+      expect(message.contains('tomorrow msg'), isTrue);
+    });
+
+    test('Groceries before 4pm -> today', () async {
+      final message = await buildDeliveryMessage(
+        cartCategories: ['Groceries'],
+        firestore: firestore,
+        now: DateTime(2024, 1, 1, 15, 10),
+      );
+      expect(message.contains('today msg'), isTrue);
+    });
+
+    test('Groceries after 4pm -> tomorrow', () async {
+      final message = await buildDeliveryMessage(
+        cartCategories: ['Groceries'],
+        firestore: firestore,
+        now: DateTime(2024, 1, 1, 16, 1),
+      );
+      expect(message.contains('tomorrow msg'), isTrue);
+    });
+
+    test('Mixed cart morning', () async {
+      final message = await buildDeliveryMessage(
+        cartCategories: ['Fruits', 'Vegetables'],
+        firestore: firestore,
+        now: DateTime(2024, 1, 1, 9, 30),
+      );
+      expect(message.contains('🥬 Vegetables — tomorrow msg'), isTrue);
+      expect(message.contains('🛒 Groceries/Fruits — today msg'), isTrue);
+    });
+
+    test('Mixed cart evening', () async {
+      final message = await buildDeliveryMessage(
+        cartCategories: ['Fruits', 'Vegetables'],
+        firestore: firestore,
+        now: DateTime(2024, 1, 1, 17, 30),
+      );
+      expect(message.contains('🥬 Vegetables — tomorrow msg'), isTrue);
+      expect(message.contains('🛒 Groceries/Fruits — tomorrow msg'), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add delivery message builder with category-based rules and note handling
- integrate new builder into checkout and order tracking
- document usage and add unit tests

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898281046008331aa76686ce6742266